### PR TITLE
feat: injected the dictionary with pure TikTok brainrot

### DIFF
--- a/src/words.json
+++ b/src/words.json
@@ -580,11 +580,6 @@
     "length": 5
   },
   {
-    "word": "rizz",
-    "definition": "Slang for charisma or charm, particularly in the context of attracting a romantic interest.",
-    "length": 4
-  },
-  {
     "word": "cheugy",
     "definition": "Used to describe something outdated or trying too hard to be trendy—often applied to millennial aesthetics.",
     "length": 6
@@ -844,11 +839,6 @@
     "length": 9
   },
   {
-    "word": "gyatt",
-    "definition": "Internet slang, usually exclaimed by males upon seeing someone with a curvy body; derived from \"goddamn\" and popularized on TikTok and Twitch.",
-    "length": 5
-  },
-  {
     "word": "pegging",
     "definition": "A sexual practice where a woman penetrates a man anally with a strap-on dildo; often referenced in internet discourse and meme culture.",
     "length": 7
@@ -972,10 +962,5 @@
     "word": "pick me girl",
     "definition": "A woman who seeks male validation by putting down other women; often used negatively in social media discourse.",
     "length": 12
-  },
-  {
-    "word": "girlboss",
-    "definition": "Originally empowering slang for ambitious women, now used ironically to mock performative corporate feminism.",
-    "length": 8
   }
 ]

--- a/src/words.json
+++ b/src/words.json
@@ -832,5 +832,150 @@
     "word": "hawk tuah",
     "definition": "A viral slang phrase mimicking the sound of spitting, popularized by a TikTok meme for its bold and humorous delivery.",
     "length": 9
+  },
+  {
+    "word": "diddy party",
+    "definition": "Refers to luxurious and exclusive parties thrown by music mogul Sean \"Diddy\" Combs, often used to imply a high-class vibe or social flex.",
+    "length": 11
+  },
+  {
+    "word": "hizru boy",
+    "definition": "A viral slang term, typically referencing a stylish or mysterious guy with online clout or niche appeal; origin and usage vary by community.",
+    "length": 9
+  },
+  {
+    "word": "gyatt",
+    "definition": "Internet slang, usually exclaimed by males upon seeing someone with a curvy body; derived from \"goddamn\" and popularized on TikTok and Twitch.",
+    "length": 5
+  },
+  {
+    "word": "pegging",
+    "definition": "A sexual practice where a woman penetrates a man anally with a strap-on dildo; often referenced in internet discourse and meme culture.",
+    "length": 7
+  },
+  {
+    "word": "fine shyt",
+    "definition": "Slang for someone who looks extremely attractive; often used to hype up appearances or outfits.",
+    "length": 9
+  },
+  {
+    "word": "shake your gyatt for rizzler",
+    "definition": "A humorous, exaggerated phrase from meme culture combining \"gyatt\" (curves) and \"rizzler\" (someone with game), implying dancing to impress.",
+    "length": 28
+  },
+  {
+    "word": "you thought you ate",
+    "definition": "A sarcastic response to someone who thinks they made a strong point or joke, implying they actually didn’t.",
+    "length": 19
+  },
+  {
+    "word": "wifie",
+    "definition": "A cute or affectionate slang term for \"wife\" or someone perceived as girlfriend/wife material.",
+    "length": 5
+  },
+  {
+    "word": "cutie",
+    "definition": "An affectionate term used to describe someone who is adorable or attractive.",
+    "length": 5
+  },
+  {
+    "word": "object",
+    "definition": "Used in meme culture to refer to lifeless or undesired things, often in a humorous, dehumanizing context.",
+    "length": 6
+  },
+  {
+    "word": "get out",
+    "definition": "A reaction phrase used to dismiss someone or something shocking, cringy, or unexpected; also tied to the horror film title.",
+    "length": 7
+  },
+  {
+    "word": "dishwasher",
+    "definition": "Used pejoratively in outdated or sexist memes to refer to women, especially in satire; generally discouraged.",
+    "length": 10
+  },
+  {
+    "word": "abduction material",
+    "definition": "A meme phrase for someone who looks too innocent or oblivious, as if they’d get snatched in a movie or show.",
+    "length": 18
+  },
+  {
+    "word": "preorder",
+    "definition": "Originally used for reserving items before release, now memed to refer to treating a partner too nicely too early.",
+    "length": 8
+  },
+  {
+    "word": "a hoe final form is religion woman",
+    "definition": "A meme phrase implying that someone who used to be promiscuous eventually becomes deeply religious, often used humorously or satirically.",
+    "length": 34
+  },
+  {
+    "word": "expired",
+    "definition": "Used to describe someone who is no longer relevant, attractive, or \"in their prime\"; often used harshly in meme slang.",
+    "length": 7
+  },
+  {
+    "word": "chill guy",
+    "definition": "A laid-back, nonchalant male archetype who doesn’t get involved in drama; sometimes used ironically.",
+    "length": 9
+  },
+  {
+    "word": "quandale dingle",
+    "definition": "A fictional meme character with a distorted face and humorous backstory; popular in absurdist meme culture.",
+    "length": 15
+  },
+  {
+    "word": "shawties",
+    "definition": "Slang for attractive women, derived from \"shorty\"; often used in rap or internet culture.",
+    "length": 8
+  },
+  {
+    "word": "thot",
+    "definition": "Acronym for \"That Hoe Over There\"; derogatory slang for a woman perceived as promiscuous, often used in meme contexts.",
+    "length": 4
+  },
+  {
+    "word": "beaters",
+    "definition": "Refers to tank tops, commonly known as \"wife beaters\"; controversial slang often used in streetwear or meme culture.",
+    "length": 7
+  },
+  {
+    "word": "double homicide",
+    "definition": "Meme phrase used to describe a savage verbal takedown or harsh insult; originated from a viral reality show clip.",
+    "length": 15
+  },
+  {
+    "word": "prime",
+    "definition": "Used to describe someone at their peak appearance or influence; often referenced when discussing attractiveness or success.",
+    "length": 5
+  },
+  {
+    "word": "comeback",
+    "definition": "A return to relevance or improvement after being dismissed or \"cancelled\"; commonly used for celebrities or exes.",
+    "length": 8
+  },
+  {
+    "word": "mother",
+    "definition": "Used in stan and meme culture to refer to iconic women (e.g., Beyoncé, Lady Gaga) as the ultimate source of inspiration.",
+    "length": 6
+  },
+  {
+    "word": "girl dinner",
+    "definition": "A TikTok trend where women show minimalist, random snack plates as their full meals; humorous and relatable content.",
+    "length": 11
+  },
+  {
+    "word": "hot girl walk",
+    "definition": "A trend where women take empowering walks while listening to music or affirmations, promoting wellness and confidence.",
+    "length": 13
+  },
+  {
+    "word": "pick me girl",
+    "definition": "A woman who seeks male validation by putting down other women; often used negatively in social media discourse.",
+    "length": 12
+  },
+  {
+    "word": "girlboss",
+    "definition": "Originally empowering slang for ambitious women, now used ironically to mock performative corporate feminism.",
+    "length": 8
   }
 ]


### PR DESCRIPTION
#### This PR expands the meme dictionary with a fresh batch of internet slang, TikTok-core phrases, and woman-coded brainrot terms. The goal is to stay culturally relevant, cover viral expressions, and add more chaotic energy to the dataset.

## What’s Included:
####  Words like:

 - `diddy party`

- `gyatt`

- `you thought you ate`

-  `fine shyt`

and 22+ more

## Each word includes:

- word (string)

- definition (accurate but meme-aware)

- length (character count)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded the slang vocabulary with a wide range of contemporary terms and detailed definitions.
  - New entries reflect trends from modern internet and social media culture, enriching the language resource for users.
  - Removed outdated slang entry for "rizz."
<!-- end of auto-generated comment: release notes by coderabbit.ai -->